### PR TITLE
Refactor JavaFX UI and implement core game view features

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueDuJeu.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueDuJeu.java
@@ -2,36 +2,59 @@ package fr.umontpellier.iut.ptcgJavaFX.vues;
 
 import fr.umontpellier.iut.ptcgJavaFX.IJeu;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
 
+import java.io.IOException;
+
 public class VueDuJeu extends VBox {
 
-    private IJeu jeu;
-    private Label instruction;
-
+    private IJeu jeu; // Keep this to pass to VueJoueurActif
+    @FXML
+    private Label instructionLabel;
+    @FXML
     private VueJoueurActif panneauDuJoueurActif;
+    @FXML
+    private Button boutonPasserVueDuJeu;
 
     public VueDuJeu(IJeu jeu) {
         this.jeu = jeu;
-        this.instruction = new Label();
-        this.panneauDuJoueurActif = new VueJoueurActif(this.jeu);
 
-        getChildren().addAll(instruction, panneauDuJoueurActif);
-        this.setSpacing(15);
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("/fxml/vueDuJeu.fxml"));
+        loader.setRoot(this);
+        loader.setController(this);
+        try {
+            loader.load();
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+        // creerBindings(); // Moved to initialize()
+    }
 
-        creerBindings();
+    @FXML
+    private void initialize() {
+        if (panneauDuJoueurActif != null) {
+            panneauDuJoueurActif.setJeu(this.jeu); // Pass game reference
+            panneauDuJoueurActif.postInit();      // Initialize VueJoueurActif's bindings & listeners
+        }
+        creerBindings(); // Now call bindings for VueDuJeu itself
+    }
+
+    @FXML
+    private void actionPasserVueDuJeu(ActionEvent event) {
+        if (this.jeu != null) {
+            this.jeu.passerAEteChoisi(); // Or a different action if this button is for something else
+            System.out.println("Bouton Passer de VueDuJeu cliqué"); // For differentiation
+        }
     }
 
     public void creerBindings() {
-        if (jeu != null && jeu.instructionProperty() != null) {
-            instruction.textProperty().bind(jeu.instructionProperty());
+        if (jeu != null && jeu.instructionProperty() != null && instructionLabel != null) {
+            instructionLabel.textProperty().bind(jeu.instructionProperty());
         }
-
-        if (panneauDuJoueurActif != null) {
-            panneauDuJoueurActif.lierAuJoueurActifDuJeu();
-        }
+        // The binding for panneauDuJoueurActif related to joueurActifProperty is handled by its own postInit now.
     }
 }

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -1,6 +1,23 @@
-@import url('https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&display=swap');
-
 .root {
-    -fx-text-fill: black;
-    -fx-font-size: 12;
+    -fx-font-family: "Verdana";
+}
+
+.bordered-titled-title {
+    -fx-background-color: white;
+    -fx-translate-y: -10;
+    -fx-translate-x: 10;
+}
+.bordered-titled-border {
+    -fx-content-display: graphically;
+    -fx-border-color: black;
+    -fx-border-width: 1;
+    -fx-border-radius: 6;
+    -fx-background-radius: 6;
+}
+.bordered-titled-content {
+    -fx-padding: 18 5 5 5;
+}
+
+.text-18px {
+    -fx-font-size: 18px;
 }

--- a/src/main/resources/fxml/VueJoueurActif.fxml
+++ b/src/main/resources/fxml/VueJoueurActif.fxml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
-<?import java.util.*?>
-<?import javafx.scene.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 
-<VBox>
-    <Label fx:id="nomDuJoueurLabel"></Label>
+<VBox fx:controller="fr.umontpellier.iut.ptcgJavaFX.vues.VueJoueurActif"
+      xmlns:fx="http://javafx.com/fxml/1"
+      stylesheets="@../css/style.css"
+      spacing="10">
+    <Label fx:id="nomDuJoueurLabel" styleClass="text-18px"/>
+    <Label fx:id="pokemonActifLabel" styleClass="text-18px"/>
+    <HBox fx:id="panneauMainHBox" spacing="5"/>
+    <HBox fx:id="panneauBancHBox" spacing="5" alignment="CENTER"/>
+    <Button fx:id="passerButton" text="Passer" onAction="#actionPasserParDefaut" styleClass="text-18px"/>
 </VBox>

--- a/src/main/resources/fxml/vueDuJeu.fxml
+++ b/src/main/resources/fxml/vueDuJeu.fxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import fr.umontpellier.iut.ptcgJavaFX.vues.VueJoueurActif?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox fx:controller="fr.umontpellier.iut.ptcgJavaFX.vues.VueDuJeu"
+      spacing="15"
+      stylesheets="@../css/style.css"
+      xmlns:fx="http://javafx.com/fxml/1"
+      xmlns="http://javafx.com/javafx/11.0.1">
+
+    <Label fx:id="instructionLabel" styleClass="text-18px"/>
+    <VueJoueurActif fx:id="panneauDuJoueurActif"/>
+    <Button fx:id="boutonPasserVueDuJeu" text="Passer (VueDuJeu)" styleClass="text-18px" onAction="#actionPasserVueDuJeu"/>
+
+</VBox>

--- a/src/test/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueDuJeuTest.java
+++ b/src/test/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueDuJeuTest.java
@@ -1,0 +1,93 @@
+package fr.umontpellier.iut.ptcgJavaFX.vues;
+
+import fr.umontpellier.iut.ptcgJavaFX.IJeu;
+import fr.umontpellier.iut.ptcgJavaFX.IJoueur; // Required for VueJoueurActif
+import javafx.application.Platform;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.embed.swing.JFXPanel;
+import javafx.event.ActionEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VueDuJeuTest {
+
+    @Mock
+    private IJeu mockJeu;
+    @Mock
+    private IJoueur mockJoueur; // For VueJoueurActif's needs if its init is triggered
+
+    // To mock properties that VueDuJeu and VueJoueurActif will interact with
+    private SimpleStringProperty instructionProperty;
+    private SimpleObjectProperty<IJoueur> joueurActifPropertyJeu;
+
+
+    @BeforeAll
+    static void initToolkit() {
+        new JFXPanel(); // Initializes JavaFX environment to prevent IllegalStateException
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Initialize properties for mockJeu
+        instructionProperty = new SimpleStringProperty("Initial instruction");
+        joueurActifPropertyJeu = new SimpleObjectProperty<>(null); // Initially no active player
+
+        // Define default behavior for mockJeu properties
+        // These are crucial as VueDuJeu's initialize and creerBindings will try to access them
+        when(mockJeu.instructionProperty()).thenReturn(instructionProperty);
+
+        // VueJoueurActif (created by VueDuJeu's FXML) will need joueurActifProperty from IJeu
+        // and the player will need its own properties.
+        // For simplicity in VueDuJeuTest, we mainly care that VueJoueurActif can be instantiated.
+        // Its detailed testing is for VueJoueurActifTest.
+        // So, mockJeu.joueurActifProperty() is needed by VueJoueurActif.postInit() -> lierAuJoueurActifDuJeu()
+        when(mockJeu.joueurActifProperty()).thenReturn(joueurActifPropertyJeu);
+    }
+
+    @Test
+    void testFxmlLoadingAndFieldInjection() throws InterruptedException {
+        final VueDuJeu[] vueDuJeu = new VueDuJeu[1];
+        Platform.runLater(() -> {
+            vueDuJeu[0] = new VueDuJeu(mockJeu);
+            assertNotNull(vueDuJeu[0].instructionLabel, "instructionLabel should be injected by FXML in VueDuJeu");
+            assertNotNull(vueDuJeu[0].panneauDuJoueurActif, "panneauDuJoueurActif should be injected by FXML in VueDuJeu");
+            assertNotNull(vueDuJeu[0].boutonPasserVueDuJeu, "boutonPasserVueDuJeu should be injected by FXML");
+        });
+        Thread.sleep(500); // Allow Platform.runLater to execute
+    }
+
+    @Test
+    void testCreerBindingsInstructionLabel() throws InterruptedException {
+        final VueDuJeu[] vueDuJeu = new VueDuJeu[1];
+        Platform.runLater(() -> {
+            vueDuJeu[0] = new VueDuJeu(mockJeu); // This calls initialize(), which calls creerBindings()
+            // Check initial text
+            assertEquals("Initial instruction", vueDuJeu[0].instructionLabel.getText(), "Instruction label should display initial text.");
+            // Change property and check if label updates
+            instructionProperty.set("New instruction");
+            assertEquals("New instruction", vueDuJeu[0].instructionLabel.getText(), "Instruction label should update when property changes.");
+        });
+        Thread.sleep(500); // Allow Platform.runLater to execute
+    }
+
+    @Test
+    void testActionPasserVueDuJeu() throws InterruptedException {
+        final VueDuJeu[] vueDuJeu = new VueDuJeu[1];
+        Platform.runLater(() -> {
+            vueDuJeu[0] = new VueDuJeu(mockJeu);
+            // Directly call the FXML action handler method
+            vueDuJeu[0].actionPasserVueDuJeu(new ActionEvent());
+            verify(mockJeu).passerAEteChoisi();
+        });
+        Thread.sleep(500); // Allow Platform.runLater to execute
+    }
+}

--- a/src/test/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActifTest.java
+++ b/src/test/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActifTest.java
@@ -1,0 +1,173 @@
+package fr.umontpellier.iut.ptcgJavaFX.vues;
+
+import fr.umontpellier.iut.ptcgJavaFX.ICarte;
+import fr.umontpellier.iut.ptcgJavaFX.IJeu;
+import fr.umontpellier.iut.ptcgJavaFX.IJoueur;
+import fr.umontpellier.iut.ptcgJavaFX.IPokemon;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.embed.swing.JFXPanel;
+import javafx.event.ActionEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.Button;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VueJoueurActifTest {
+
+    @Mock
+    private IJeu mockJeu;
+    @Mock
+    private IJoueur mockJoueurActif;
+    @Mock
+    private IPokemon mockPokemonActifPokemon, mockBenchPokemon1;
+    @Mock
+    private ICarte mockPokemonActifCarte, mockMainCarte1, mockBenchCarte1;
+
+    private VueJoueurActif vueJoueurActif;
+
+    // Observable properties for mocking
+    private SimpleObjectProperty<IJoueur> joueurActifPropertyJeu;
+    private SimpleObjectProperty<IPokemon> pokemonActifPropertyJoueur;
+    private ObservableList<ICarte> mainDuJoueurList;
+    private ObservableList<IPokemon> bancDuJoueurList;
+
+
+    @BeforeAll
+    static void initToolkit() {
+        new JFXPanel(); // Initializes JavaFX environment
+    }
+
+    @BeforeEach
+    void setUp() throws InterruptedException {
+        // Initialize observable properties
+        joueurActifPropertyJeu = new SimpleObjectProperty<>(null);
+        pokemonActifPropertyJoueur = new SimpleObjectProperty<>(null);
+        mainDuJoueurList = FXCollections.observableArrayList();
+        bancDuJoueurList = FXCollections.observableArrayList();
+
+        // Configure mock IJoueur properties
+        when(mockJoueurActif.pokemonActifProperty()).thenReturn(pokemonActifPropertyJoueur);
+        when(mockJoueurActif.getMain()).thenReturn(mainDuJoueurList);
+        when(mockJoueurActif.getBanc()).thenReturn(bancDuJoueurList);
+        when(mockJoueurActif.getNom()).thenReturn("Test Player");
+
+
+        // Configure mock IJeu to return the joueurActifProperty
+        when(mockJeu.joueurActifProperty()).thenReturn(joueurActifPropertyJeu);
+
+        // Instantiate VueJoueurActif on FX thread
+        Platform.runLater(() -> {
+            vueJoueurActif = new VueJoueurActif(); // Loads its own FXML
+            vueJoueurActif.setJeu(mockJeu);      // Set the game instance
+            vueJoueurActif.postInit();          // Initialize listeners and bindings
+        });
+        Thread.sleep(500); // Allow Platform.runLater to complete and FXML to load
+    }
+
+    @Test
+    void testFxmlLoadingAndFieldInjection() {
+        assertNotNull(vueJoueurActif.nomDuJoueurLabel, "nomDuJoueurLabel should be injected");
+        assertNotNull(vueJoueurActif.pokemonActifLabel, "pokemonActifLabel should be injected");
+        assertNotNull(vueJoueurActif.panneauMainHBox, "panneauMainHBox should be injected");
+        assertNotNull(vueJoueurActif.panneauBancHBox, "panneauBancHBox should be injected");
+        assertNotNull(vueJoueurActif.passerButton, "passerButton should be injected");
+    }
+
+    @Test
+    void testInitialDisplayWithNoPlayer() {
+        assertEquals("Pas de joueur actif", vueJoueurActif.nomDuJoueurLabel.getText());
+        assertEquals("Aucun Pokémon actif", vueJoueurActif.pokemonActifLabel.getText());
+        assertTrue(vueJoueurActif.panneauMainHBox.getChildren().isEmpty());
+        assertTrue(vueJoueurActif.panneauBancHBox.getChildren().isEmpty());
+    }
+
+    @Test
+    void testDisplayWhenPlayerBecomesActive() throws InterruptedException {
+        // Mock Pokemon actif details
+        when(mockPokemonActifPokemon.getCartePokemon()).thenReturn(mockPokemonActifCarte);
+        when(mockPokemonActifCarte.getNom()).thenReturn("Pikachu");
+        pokemonActifPropertyJoueur.set(mockPokemonActifPokemon); // Set Pokemon actif for player
+
+        // Mock Main card details
+        when(mockMainCarte1.getNom()).thenReturn("Potion");
+        mainDuJoueurList.add(mockMainCarte1);
+
+        // Mock Bench Pokemon details
+        when(mockBenchPokemon1.getCartePokemon()).thenReturn(mockBenchCarte1);
+        when(mockBenchCarte1.getNom()).thenReturn("Magikarp");
+        bancDuJoueurList.add(mockBenchPokemon1);
+
+        Platform.runLater(() -> {
+            joueurActifPropertyJeu.set(mockJoueurActif); // Set player as active in the game
+        });
+        Thread.sleep(500); // Allow listeners to fire and UI to update
+
+        assertEquals("C'est au tour de : Test Player", vueJoueurActif.nomDuJoueurLabel.getText());
+        assertEquals("Pokémon actif : Pikachu", vueJoueurActif.pokemonActifLabel.getText());
+        assertEquals(1, vueJoueurActif.panneauMainHBox.getChildren().size(), "Main should have 1 card");
+        assertEquals("Potion", ((Button) vueJoueurActif.panneauMainHBox.getChildren().get(0)).getText());
+        assertEquals(1, vueJoueurActif.panneauBancHBox.getChildren().size(), "Bench should have 1 Pokemon");
+        assertEquals("Magikarp", ((Button) vueJoueurActif.panneauBancHBox.getChildren().get(0)).getText());
+    }
+
+    @Test
+    void testPlacerMainButtonAction() throws InterruptedException {
+        when(mockMainCarte1.getNom()).thenReturn("PotionCard");
+        when(mockMainCarte1.getId()).thenReturn("potion1");
+        mainDuJoueurList.add(mockMainCarte1);
+
+        Platform.runLater(() -> joueurActifPropertyJeu.set(mockJoueurActif));
+        Thread.sleep(500);
+
+        assertFalse(vueJoueurActif.panneauMainHBox.getChildren().isEmpty(), "Main HBox should not be empty");
+        Button cardButton = (Button) vueJoueurActif.panneauMainHBox.getChildren().get(0);
+
+        Platform.runLater(cardButton::fire);
+        Thread.sleep(500);
+
+        verify(mockJeu).uneCarteDeLaMainAEteChoisie("potion1");
+    }
+
+    @Test
+    void testPlacerBancButtonAction() throws InterruptedException {
+        when(mockBenchPokemon1.getCartePokemon()).thenReturn(mockBenchCarte1);
+        when(mockBenchCarte1.getNom()).thenReturn("BenchMon");
+        when(mockBenchCarte1.getId()).thenReturn("benchMon1"); // ICarte has getId()
+        bancDuJoueurList.add(mockBenchPokemon1);
+
+        Platform.runLater(() -> joueurActifPropertyJeu.set(mockJoueurActif));
+        Thread.sleep(500);
+
+        assertFalse(vueJoueurActif.panneauBancHBox.getChildren().isEmpty(), "Banc HBox should not be empty");
+        Button benchPokemonButton = (Button) vueJoueurActif.panneauBancHBox.getChildren().get(0);
+
+        Platform.runLater(benchPokemonButton::fire);
+        Thread.sleep(500);
+
+        verify(mockJeu).unPokemonDuBancAEteChoisi("benchMon1");
+    }
+
+
+    @Test
+    void testActionPasserParDefaut() throws InterruptedException {
+         // Ensure vueJoueurActif.jeu is set, which is done in setUp()
+        Platform.runLater(() -> {
+             // Directly call the FXML action handler method
+            vueJoueurActif.actionPasserParDefaut(new ActionEvent());
+            verify(mockJeu).passerAEteChoisi();
+        });
+        Thread.sleep(500);
+    }
+}


### PR DESCRIPTION
This commit addresses several key UI enhancements based on your project guidelines:

- Refactored `VueJoueurActif` (Step 7):
    - Now loads its layout from `VueJoueurActif.fxml`.
    - UI components (`nomDuJoueurLabel`, `pokemonActifLabel`, `panneauMainHBox`, `passerButton`) are defined in FXML.
    - Uses `style.css` for an 18px font size applied to relevant elements.
    - `VueJoueurActif.java` handles FXML loading, controller logic, and dynamic updates.

- Refactored `VueDuJeu` (Step 8):
    - Now loads its layout from `vueDuJeu.fxml`.
    - Defines `instructionLabel`, the nested `VueJoueurActif` component, and `boutonPasserVueDuJeu` in FXML.
    - `VueDuJeu.java` handles FXML loading and initialization, including passing the `IJeu` reference to `VueJoueurActif`.

- Implemented Bench Display (Step 9):
    - Added `panneauBancHBox` to `VueJoueurActif.fxml`.
    - `VueJoueurActif.java` now includes logic to display Pokémon on the active player's bench.
    - Buttons for bench Pokémon are created dynamically, styled, and trigger `jeu.unPokemonDuBancAEteChoisi()` on interaction.
    - The bench display updates automatically when the active player or their bench changes.

- Added Unit Tests:
    - Created `VueDuJeuTest.java` and `VueJoueurActifTest.java`.
    - Tests cover FXML loading, proper initialization of components, interactions with mocked game logic (`IJeu`), and verification of UI updates in response to game state changes (e.g., active player, hand, bench).
    - Utilizes JUnit 5 and Mockito.

These changes align the UI structure with FXML best practices, improve maintainability, and implement essential visual components for gameplay.