### PR TITLE
Regarding the layout, I've made the central game area expand vertically.

### DIFF
--- a/EXPECTED_UI_DESCRIPTION.md
+++ b/EXPECTED_UI_DESCRIPTION.md
@@ -17,7 +17,7 @@ This component is a `VBox` (vertical layout) providing the main game interface. 
     *   A `Label` (`instructionLabel`) displaying the current game instruction (e.g., "Choose a Pokémon to be active", "Player John's turn").
     *   Styled by `instruction-area`: This gives it a light gray background, padding, a bottom border, and an 18px font size, making it a distinct instruction bar.
 *   **Middle Element**:
-    *   An `HBox` (horizontal layout) containing two main sections, side-by-side, with 20px spacing between them:
+    *   An `HBox` (horizontal layout) containing two main sections, side-by-side, with 20px spacing between them. This `HBox` is configured to grow vertically (`VBox.vgrow="ALWAYS"`), taking up the available space below the instruction label.
         *   **Left Side**: The `VueJoueurActif` component (active player's view).
         *   **Right Side**: The `VueAdversaire` component (opponent's view).
 

--- a/src/main/resources/fxml/vueDuJeu.fxml
+++ b/src/main/resources/fxml/vueDuJeu.fxml
@@ -14,7 +14,7 @@
       xmlns="http://javafx.com/javafx/11.0.1">
 
     <Label fx:id="instructionLabel" styleClass="instruction-area"/>
-    <HBox spacing="20" alignment="TOP_CENTER">
+    <HBox spacing="20" alignment="TOP_CENTER" VBox.vgrow="ALWAYS">
         <VueJoueurActif fx:id="panneauDuJoueurActif"/>
         <VueAdversaire fx:id="vueAdversaire"/>
     </HBox>


### PR DESCRIPTION
Here's what I did:

- Modified `vueDuJeu.fxml`:
    - Added `VBox.vgrow="ALWAYS"` to the HBox containing the `VueJoueurActif` and `VueAdversaire` components. This allows the main game display area to expand vertically and fill available space below the instruction label.

- Updated `EXPECTED_UI_DESCRIPTION.md`:
    - Documented the new vertically expanding behavior of the central game area.