### PR TITLE
feat: Display Pokémon HP for active and benched Pokémon

### DIFF
--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -198,3 +198,10 @@
     /* -fx-border-width: 1px; */
     /* -fx-padding: 5px; */
 }
+
+.hp-label {
+    -fx-font-size: 11px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #2c5e2e; /* A shade of dark green */
+    -fx-padding: 1px 0px 1px 3px; /* Top, Right, Bottom, Left padding */
+}

--- a/src/main/resources/fxml/VueJoueurActif.fxml
+++ b/src/main/resources/fxml/VueJoueurActif.fxml
@@ -18,7 +18,7 @@
     <!-- Main HBox for Active Pokemon and Bench -->
     <HBox spacing="20" alignment="CENTER_LEFT">
         <!-- VBox for Active Pokemon -->
-        <VBox spacing="5" alignment="CENTER_LEFT">
+        <VBox fx:id="pokemonActifVBox" spacing="5" alignment="CENTER_LEFT">
             <children>
                 <Button fx:id="pokemonActifButton" styleClass="card-button text-18px" onAction="#onPokemonActifButtonClick"/>
                 <HBox fx:id="energiePokemonActifHBox" spacing="2" alignment="CENTER_LEFT"/>

--- a/src/main/resources/fxml/vueAdversaire.fxml
+++ b/src/main/resources/fxml/vueAdversaire.fxml
@@ -23,7 +23,7 @@
     <HBox spacing="20" alignment="TOP_LEFT">
         <children>
             <!-- Inner VBox for Active Pokemon Area -->
-            <VBox spacing="5" alignment="TOP_LEFT">
+            <VBox fx:id="opponentPokemonActifVBox" spacing="5" alignment="TOP_LEFT">
                 <children>
                     <Label text="Pokémon Actif de l'adversaire:" styleClass="text-18px"/>
                     <Button fx:id="opponentPokemonActifButton" text="Pokemon Actif Adv." styleClass="card-button text-18px" minHeight="60" onAction="#handleOpponentActivePokemonClick"/>


### PR DESCRIPTION
I've implemented the display of Hit Points (HP) for all Pokémon visible to you:
- Your active Pokémon
- Your benched Pokémon
- Your opponent's active Pokémon
- Your opponent's benched Pokémon

Here are the changes I made:

1.  **VueJoueurActif.java & fxml/VueJoueurActif.fxml:**
    *   I modified `placerPokemonActif()` to add an HP label to the active Pokémon's display area. The HP label is bound to the `pointsDeVieProperty` of the `IPokemon`.
    *   I modified `creerPokemonBancNode()` to include an HP label in each benched Pokémon's display node, also bound to `pointsDeVieProperty`.
    *   I added `fx:id="pokemonActifVBox"` to FXML for easier access to the active Pokémon's container.

2.  **VueAdversaire.java & fxml/vueAdversaire.fxml:**
    *   I modified `placerPokemonActifAdversaire()` to add an HP label for the opponent's active Pokémon, bound to its `pointsDeVieProperty`.
    *   I modified `creerOpponentPokemonBancNode()` to include an HP label for each of the opponent's benched Pokémon, bound to `pointsDeVieProperty`.
    *   I added `fx:id="opponentPokemonActifVBox"` to FXML for the opponent's active Pokémon container.

3.  **css/style.css:**
    *   I added a new CSS class `.hp-label` to provide consistent styling for all HP labels. This class is applied programmatically to the newly created labels.

The HP display updates dynamically based on changes to the Pokémon's `pointsDeVieProperty`. Labels show "HP: X" and "HP: --" if data is unavailable.