### PR TITLE
fix: Add missing import for javafx.beans.binding.Bindings

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueAdversaire.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueAdversaire.java
@@ -4,6 +4,7 @@ import fr.umontpellier.iut.ptcgJavaFX.ICarte;
 import fr.umontpellier.iut.ptcgJavaFX.IJeu;
 import fr.umontpellier.iut.ptcgJavaFX.IJoueur;
 import fr.umontpellier.iut.ptcgJavaFX.IPokemon;
+import javafx.beans.binding.Bindings; // Added import
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.ListChangeListener;

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
@@ -5,6 +5,7 @@ import fr.umontpellier.iut.ptcgJavaFX.IJeu;
 import fr.umontpellier.iut.ptcgJavaFX.IJoueur;
 import fr.umontpellier.iut.ptcgJavaFX.IPokemon;
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.pokemon.CartePokemon; // Ensure this is uncommented or present
+import javafx.beans.binding.Bindings; // Added import
 import javafx.beans.binding.StringBinding;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;


### PR DESCRIPTION
This commit resolves compilation errors (`cannot find symbol: variable Bindings`) by adding the required import statement `import javafx.beans.binding.Bindings;` to the following files:
- src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
- src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueAdversaire.java

These imports are necessary for using `Bindings.createStringBinding` to dynamically update the HP display labels for Pokémon.