### PR TITLE
feat: Display weakness, resistance, and retreat cost

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/ICarte.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/ICarte.java
@@ -8,4 +8,8 @@ public interface ICarte {
     String getNom();
     String getCode();
     Type getTypeEnergie();
+
+    fr.umontpellier.iut.ptcgJavaFX.mecanique.Type getFaiblesse();
+    fr.umontpellier.iut.ptcgJavaFX.mecanique.Type getResistance();
+    int getCoutRetraite();
 }

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/Carte.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/Carte.java
@@ -102,4 +102,19 @@ public abstract class Carte implements Comparable<Carte>, ICarte {
         return this.nom.compareTo(o.nom);
     }
 
+    // Add these methods to Carte.java
+    @Override
+    public fr.umontpellier.iut.ptcgJavaFX.mecanique.Type getFaiblesse() {
+        return null; // Default for non-Pokemon cards
+    }
+
+    @Override
+    public fr.umontpellier.iut.ptcgJavaFX.mecanique.Type getResistance() {
+        return null; // Default for non-Pokemon cards
+    }
+
+    @Override
+    public int getCoutRetraite() {
+        return 0; // Default for non-Pokemon cards
+    }
 }

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/pokemon/CartePokemon.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/pokemon/CartePokemon.java
@@ -62,6 +62,11 @@ public abstract class CartePokemon extends Carte {
         return resistance;
     }
 
+    // Add this new method
+    public int getCoutRetraite() {
+        return this.coutRetraite; // Access the private final field
+    }
+
     public int getCoutRetraite(Pokemon pokemon) {
         return coutRetraite;
     }

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueAdversaire.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueAdversaire.java
@@ -268,6 +268,9 @@ public class VueAdversaire extends VBox {
         // Remove existing HP label if present
         if (opponentPokemonActifVBox != null) {
             opponentPokemonActifVBox.getChildren().removeIf(node -> "hpLabelOpponentActif".equals(node.getId()));
+            opponentPokemonActifVBox.getChildren().removeIf(node -> "weaknessLabelOpponentActif".equals(node.getId()));
+            opponentPokemonActifVBox.getChildren().removeIf(node -> "resistanceLabelOpponentActif".equals(node.getId()));
+            opponentPokemonActifVBox.getChildren().removeIf(node -> "retreatLabelOpponentActif".equals(node.getId()));
         }
 
         if (opponentPokemonActifButton != null) { // This button is inside opponentPokemonActifVBox
@@ -311,6 +314,41 @@ public class VueAdversaire extends VBox {
                     } else {
                          opponentPokemonActifVBox.getChildren().add(hpLabel); // Add if VBox has fewer than 2 children initially
                     }
+
+                    // Get ICarte for additional properties
+                    ICarte carte = opponentPokemonForBinding.getCartePokemon();
+
+                    // Weakness Display
+                    fr.umontpellier.iut.ptcgJavaFX.mecanique.Type faiblesseType = carte.getFaiblesse();
+                    Label weaknessLabel = new Label();
+                    weaknessLabel.setId("weaknessLabelOpponentActif");
+                    weaknessLabel.getStyleClass().add("hp-label"); // Using same style for now
+                    if (faiblesseType != null) {
+                        weaknessLabel.setText("Weakness: " + faiblesseType.name());
+                    } else {
+                        weaknessLabel.setText("Weakness: None");
+                    }
+                    opponentPokemonActifVBox.getChildren().add(weaknessLabel);
+
+                    // Resistance Display
+                    fr.umontpellier.iut.ptcgJavaFX.mecanique.Type resistanceType = carte.getResistance();
+                    Label resistanceLabel = new Label();
+                    resistanceLabel.setId("resistanceLabelOpponentActif");
+                    resistanceLabel.getStyleClass().add("hp-label"); // Using same style for now
+                    if (resistanceType != null) {
+                        resistanceLabel.setText("Resistance: " + resistanceType.name());
+                    } else {
+                        resistanceLabel.setText("Resistance: None");
+                    }
+                    opponentPokemonActifVBox.getChildren().add(resistanceLabel);
+
+                    // Retreat Cost Display
+                    int retreatCost = carte.getCoutRetraite();
+                    Label retreatLabel = new Label();
+                    retreatLabel.setId("retreatLabelOpponentActif");
+                    retreatLabel.getStyleClass().add("hp-label"); // Using same style for now
+                    retreatLabel.setText("Retreat: " + retreatCost);
+                    opponentPokemonActifVBox.getChildren().add(retreatLabel);
                 }
             } else {
                 // Display card back or clear

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
@@ -346,6 +346,9 @@ public class VueJoueurActif extends VBox {
         // Remove existing HP label if present
         if (pokemonActifVBox != null) {
             pokemonActifVBox.getChildren().removeIf(node -> "hpLabelActif".equals(node.getId()));
+            pokemonActifVBox.getChildren().removeIf(node -> "weaknessLabelActif".equals(node.getId()));
+            pokemonActifVBox.getChildren().removeIf(node -> "resistanceLabelActif".equals(node.getId()));
+            pokemonActifVBox.getChildren().removeIf(node -> "retreatLabelActif".equals(node.getId()));
         }
 
         if (pokemonActifButton != null) {
@@ -392,6 +395,41 @@ public class VueJoueurActif extends VBox {
                     else {
                         pokemonActifVBox.getChildren().add(hpLabel); // Add as first element if VBox is empty or button not found
                     }
+
+                    // Get ICarte for additional properties
+                    ICarte carte = pokemonForBinding.getCartePokemon();
+
+                    // Weakness Display
+                    fr.umontpellier.iut.ptcgJavaFX.mecanique.Type faiblesseType = carte.getFaiblesse();
+                    Label weaknessLabel = new Label();
+                    weaknessLabel.setId("weaknessLabelActif");
+                    weaknessLabel.getStyleClass().add("hp-label"); // Using same style for now
+                    if (faiblesseType != null) {
+                        weaknessLabel.setText("Weakness: " + faiblesseType.name());
+                    } else {
+                        weaknessLabel.setText("Weakness: None");
+                    }
+                    pokemonActifVBox.getChildren().add(weaknessLabel);
+
+                    // Resistance Display
+                    fr.umontpellier.iut.ptcgJavaFX.mecanique.Type resistanceType = carte.getResistance();
+                    Label resistanceLabel = new Label();
+                    resistanceLabel.setId("resistanceLabelActif");
+                    resistanceLabel.getStyleClass().add("hp-label"); // Using same style for now
+                    if (resistanceType != null) {
+                        resistanceLabel.setText("Resistance: " + resistanceType.name());
+                    } else {
+                        resistanceLabel.setText("Resistance: None");
+                    }
+                    pokemonActifVBox.getChildren().add(resistanceLabel);
+
+                    // Retreat Cost Display
+                    int retreatCost = carte.getCoutRetraite();
+                    Label retreatLabel = new Label();
+                    retreatLabel.setId("retreatLabelActif");
+                    retreatLabel.getStyleClass().add("hp-label"); // Using same style for now
+                    retreatLabel.setText("Retreat: " + retreatCost);
+                    pokemonActifVBox.getChildren().add(retreatLabel);
                 }
             } else {
                 pokemonActifButton.setGraphic(VueUtils.creerImageViewPourDosCarte(LARGEUR_PKMN_ACTIF, HAUTEUR_PKMN_ACTIF)); // Show card back


### PR DESCRIPTION
I've implemented the display of Weakness, Resistance, and Retreat Cost for active Pokémon for both you and the opponent.

Changes:

1.  **Interface Modification (`ICarte.java`):**
    *   I added `getFaiblesse()`, `getResistance()`, and `getCoutRetraite()` methods to the `ICarte` interface to expose these attributes.
    *   `CartePokemon.java` was updated to provide a parameterless `getCoutRetraite()` method.
    *   `Carte.java` (base class) was updated with default implementations for these new interface methods (returning null or 0).

2.  **Player's View (`VueJoueurActif.java`):**
    *   I modified `placerPokemonActif()` to fetch and display Weakness, Resistance, and Retreat Cost for your active Pokémon.
    *   Labels are added to the `pokemonActifVBox` and updated when the active Pokémon changes.
    *   "None" is displayed if a Pokémon has no weakness or resistance.

3.  **Opponent's View (`VueAdversaire.java`):**
    *   I modified `placerPokemonActifAdversaire()` to fetch and display Weakness, Resistance, and Retreat Cost for the opponent's active Pokémon.
    *   Labels are added to the `opponentPokemonActifVBox` and updated accordingly.

4.  **Styling:**
    *   The new labels for these attributes reuse the existing "hp-label" CSS class for styling.

This feature provides you with more comprehensive information about the active Pokémon in play.