### PR TITLE
fix: Refactor retreat button state management in UI

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
@@ -299,10 +299,10 @@ public class VueJoueurActif extends VBox {
                 if (oldJoueur.recompensesProperty() != null && this.recompensesListener != null) {
                     oldJoueur.recompensesProperty().removeListener(this.recompensesListener);
                 }
-                // Unbind retreat button from old player
-                if (retreatButton != null) {
-                    retreatButton.disableProperty().unbind();
-                }
+                // Unbind retreat button from old player - REMOVED as per instruction
+                // if (retreatButton != null) {
+                //     retreatButton.disableProperty().unbind();
+                // }
             }
 
             // Update displays for newJoueur
@@ -348,13 +348,13 @@ public class VueJoueurActif extends VBox {
                     if (recompensesJoueurActifLabel != null) recompensesJoueurActifLabel.setText("R: " + tailleRecompenses);
                     if (recompensesJoueurActifImageView != null) recompensesJoueurActifImageView.setVisible(tailleRecompenses > 0);
                 }
-                // Bind retreat button to new player's peutRetraiteProperty
-                if (newJoueur.peutRetraiteProperty() != null && retreatButton != null) { // Check if property itself is null
-                    retreatButton.disableProperty().bind(newJoueur.peutRetraiteProperty().not());
-                } else if (retreatButton != null) { // Property is null, so disable button
-                    retreatButton.disableProperty().unbind();
-                    retreatButton.setDisable(true);
-                }
+                // Bind retreat button to new player's peutRetraiteProperty - REMOVED as per instruction
+                // if (newJoueur.peutRetraiteProperty() != null && retreatButton != null) {
+                //     retreatButton.disableProperty().bind(newJoueur.peutRetraiteProperty().not());
+                // } else if (retreatButton != null) {
+                //     retreatButton.disableProperty().unbind();
+                //     retreatButton.setDisable(true);
+                // }
 
             } else { // No new player (e.g. game end), clear displays
                 if (energiePokemonActifHBox != null) energiePokemonActifHBox.getChildren().clear();
@@ -363,12 +363,14 @@ public class VueJoueurActif extends VBox {
                 if (piocheJoueurActifImageView != null) piocheJoueurActifImageView.setVisible(false);
                 if (recompensesJoueurActifLabel != null) recompensesJoueurActifLabel.setText("R: 0");
                 if (recompensesJoueurActifImageView != null) recompensesJoueurActifImageView.setVisible(false);
-                // Disable retreat button if no active player
-                if (retreatButton != null) {
-                    retreatButton.disableProperty().unbind(); // Unbind first
-                    retreatButton.setDisable(true);      // Then disable
-                }
+                // Disable retreat button if no active player - REMOVED as per instruction
+                // if (retreatButton != null) {
+                //    retreatButton.disableProperty().unbind();
+                //    retreatButton.setDisable(true);
+                // }
             }
+            // Call updateUserInteractivity whenever the active player changes
+            updateUserInteractivity();
         };
         this.joueurActifProperty.addListener(this.joueurActifGlobalChangeListener);
     }
@@ -918,31 +920,19 @@ public class VueJoueurActif extends VBox {
         if (passerButton != null) {
             passerButton.setDisable(disableOthers);
         }
-        if (retreatButton != null) { // Also disable retreat button during this specific instruction
-            // We only want to disable it if 'disableOthers' is true.
-            // If 'disableOthers' is false, its state is determined by its binding to peutRetraiteProperty.
-            if (disableOthers) {
+
+        if (retreatButton != null) {
+            IJoueur joueurCourant = (joueurActifProperty != null) ? joueurActifProperty.get() : null;
+            boolean canPlayerCurrentlyRetreat = false;
+            if (joueurCourant != null && joueurCourant.peutRetraiteProperty() != null) {
+                // Ensure peutRetraiteProperty() itself is not null before calling .get()
+                canPlayerCurrentlyRetreat = joueurCourant.peutRetraiteProperty().get();
+            }
+
+            if (isChoosingNewActivePokemon) {
                 retreatButton.setDisable(true);
             } else {
-                // If not choosing new active pokemon, re-evaluate disable based on binding.
-                // This requires the binding to be set up correctly.
-                // A simple way is to rely on the joueurActifGlobalChangeListener to set the binding.
-                // If newJoueur is null or newJoueur.peutRetraiteProperty() is null or false, it will be disabled.
-                // If newJoueur.peutRetraiteProperty() is true, it will be enabled.
-                // This part might need refinement if direct control is needed here beyond what binding provides.
-                // For now, let's assume the binding correctly reflects the state when not (disableOthers).
-                // So, if disableOthers is false, we don't touch retreatButton.disable here, let binding rule.
-                // However, the prompt implies it should be disabled along with others.
-                 IJoueur joueurCourant = (joueurActifProperty != null) ? joueurActifProperty.get() : null;
-                 if (joueurCourant != null && joueurCourant.peutRetraiteProperty() != null) {
-                    // If we are not in "choosing new active" mode, the button's state should follow its binding.
-                    // No direct setDisable(false) here as that would override the binding.
-                    // The binding itself will enable/disable it.
-                    // If disableOthers is true, it means we ARE choosing a new active, so it should be disabled.
-                 } else if (retreatButton != null) {
-                    // No player or no property, should be disabled by binding logic or here if no binding active
-                    retreatButton.setDisable(true);
-                 }
+                retreatButton.setDisable(!canPlayerCurrentlyRetreat);
             }
         }
 


### PR DESCRIPTION
This commit refactors the way the retreat button's enabled/disabled state is managed in `VueJoueurActif.java`.

Previously, the button's `disableProperty` was bound directly to the active player's `peutRetraiteProperty` within the
`joueurActifGlobalChangeListener`. Additional logic in `updateUserInteractivity` handled disabling the button when the player was choosing a new active Pokémon.

This change centralizes the control of the retreat button's state into the `updateUserInteractivity` method. This method now explicitly sets the button's `disable` state based on both the `isChoosingNewActivePokemon` flag and the value of `joueurActif.peutRetraiteProperty().get()`. The direct binding in `joueurActifGlobalChangeListener` has been removed to avoid conflicting logic.

A call to `updateUserInteractivity()` has been ensured within `joueurActifGlobalChangeListener` so that the button's state is correctly updated when the active player changes.

This change aims to make the retreat button's visibility and interactivity more robust and directly tied to all relevant UI state conditions.