### PR TITLE
fix: Resolve compilation errors in Lanturn talent implementation

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/pokemon/Lanturn.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/pokemon/Lanturn.java
@@ -1,5 +1,8 @@
 package fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.pokemon;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.Joueur;
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.Pokemon;
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.Type;

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/talent/EtatChoixEnergiePourEnergyGrounding.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/talent/EtatChoixEnergiePourEnergyGrounding.java
@@ -21,7 +21,7 @@ public class EtatChoixEnergiePourEnergyGrounding extends EtatJoueur {
         // Filter again to be sure, though previous state should pass correct list
         this.availableEnergies = availableEnergies.stream().filter(Carte::isBasicEnergy).collect(Collectors.toList());
 
-        String instruction = String.format("Select a basic energy from %s (KO) to move to Lanturn.", koPokemon.getNom());
+        String instruction = String.format("Select a basic energy from %s (KO) to move to Lanturn.", koPokemon.getCartePokemon().getNom());
         getJeu().instructionProperty().setValue(instruction);
         // The UI needs to display these availableEnergies as clickable choices.
         // Clicking one should call an appropriate method on IJeu (e.g. uneCarteEnergieAEteChoisie or uneCarteComplementaireAEteChoisie)

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/talent/EtatChoixUtiliserEnergyGrounding.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/talent/EtatChoixUtiliserEnergyGrounding.java
@@ -18,7 +18,7 @@ public class EtatChoixUtiliserEnergyGrounding extends EtatJoueur {
         this.koPokemon = koPokemon;
         this.lanturnPokemon = lanturnPokemon;
         this.availableEnergies = availableEnergies;
-        String instruction = String.format("Lanturn's Energy Grounding: Move a basic energy from %s (KO) to Lanturn? (Oui/Non)", koPokemon.getNom());
+        String instruction = String.format("Lanturn's Energy Grounding: Move a basic energy from %s (KO) to Lanturn? (Oui/Non)", koPokemon.getCartePokemon().getNom());
         getJeu().instructionProperty().setValue(instruction);
         // The UI will need to offer Yes/No. Assume Yes calls talentAEteAccepte, No calls talentAEteRefuse.
     }


### PR DESCRIPTION
This commit addresses compilation errors that arose during the implementation of Lanturn's "Energy Grounding" talent:

- Corrected calls to `koPokemon.getNom()` in `EtatChoixUtiliserEnergyGrounding.java` and `EtatChoixEnergiePourEnergyGrounding.java`. The calls now correctly use `koPokemon.getCartePokemon().getNom()` to retrieve the name.
- Added missing imports for `java.util.List` and `java.util.stream.Collectors` in `Lanturn.java`.

These changes ensure the talent implementation and related state classes compile successfully.