### PR TITLE
Gameplay Corrections Part 1: Special Conditions, Shuffling, and Effec…

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/attaque/ImpactDuDragon.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/attaque/ImpactDuDragon.java
@@ -5,35 +5,78 @@ import fr.umontpellier.iut.ptcgJavaFX.mecanique.Pokemon;
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.Carte;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ImpactDuDragon extends EnAttaque {
 
-    private int nbEnergies = 3;
+    private int nbEnergiesADefausser; // Renamed for clarity
+    private boolean discardCompleteOuImpossible;
+
     public ImpactDuDragon(Joueur joueurActif) {
         super(joueurActif);
-        getJeu().instructionProperty().setValue("Défaussez %d énergie%s".formatted(nbEnergies, nbEnergies > 1 ? "s" : ""));
-    }
+        Pokemon pokemonActif = joueur.getPokemonActif();
+        discardCompleteOuImpossible = false;
 
-    @Override
-    public void defausseEnergie(String numCarte) {
-        Pokemon pokemon = joueur.getPokemonActif();
-        List<String> choixPossibles = pokemon.getCartes().stream()
-                .filter(c -> c.getTypeEnergie() != null)
-                .map(Carte::getId)
-                .toList();
-        if (choixPossibles.contains(numCarte)) {
-            Carte carteEnergie = Carte.get(numCarte);
-            pokemon.retirerCarte(carteEnergie);
-            joueur.ajouterCarteDefausse(carteEnergie);
-            nbEnergies--;
-            if (nbEnergies == 0) {
-                finAttaque();
-            }
+        if (pokemonActif == null) {
+            nbEnergiesADefausser = 0;
+            discardCompleteOuImpossible = true; // Nothing to discard
+        } else {
+            long energiesAttachees = pokemonActif.getCartes().stream()
+                                        .filter(c -> c.getTypeEnergie() != null)
+                                        .count();
+            nbEnergiesADefausser = (int) Math.min(3, energiesAttachees);
+        }
+
+        if (nbEnergiesADefausser == 0) {
+            getJeu().instructionProperty().setValue("Impact du Dragon ! Aucune énergie à défausser.");
+            discardCompleteOuImpossible = true;
+            // Directly calling finAttaque() as per simplified approach.
+            // If this causes issues (e.g. state change during superclass constructor),
+            // it would need to be deferred (e.g., Platform.runLater or a flag for next action).
+            finAttaque();
+        } else {
+            getJeu().instructionProperty().setValue("Impact du Dragon ! Défaussez " + nbEnergiesADefausser + " énergie" + (nbEnergiesADefausser > 1 ? "s" : "") + " de " + pokemonActif.getCartePokemon().getNom() + ".");
         }
     }
 
     @Override
+    public void defausseEnergie(String numCarte) {
+        if (discardCompleteOuImpossible) {
+            finAttaque();
+            return;
+        }
+
+        Pokemon pokemon = joueur.getPokemonActif();
+        if (pokemon == null) { // Safeguard
+            finAttaque();
+            return;
+        }
+
+        List<String> choixPossibles = pokemon.getCartes().stream()
+                .filter(c -> c.getTypeEnergie() != null)
+                .map(Carte::getId)
+                .collect(Collectors.toList()); // Use Collectors.toList() for mutable list if needed by remove.
+
+        if (choixPossibles.contains(numCarte)) {
+            Carte carteEnergie = Carte.get(numCarte);
+            pokemon.retirerCarte(carteEnergie);
+            joueur.ajouterCarteDefausse(carteEnergie);
+            nbEnergiesADefausser--; // Use the adjusted count
+
+            if (nbEnergiesADefausser <= 0) { // Changed to <= for safety
+                discardCompleteOuImpossible = true;
+                getJeu().instructionProperty().setValue(pokemon.getCartePokemon().getNom() + " a défaussé les énergies requises.");
+                finAttaque();
+            } else {
+                getJeu().instructionProperty().setValue("Impact du Dragon ! Défaussez encore " + nbEnergiesADefausser + " énergie" + (nbEnergiesADefausser > 1 ? "s" : "") + ".");
+            }
+        }
+        // If invalid card choice, do nothing, wait for valid choice.
+    }
+
+    @Override
     public void passer() {
+        // Player cannot pass this action.
     }
 }
 


### PR DESCRIPTION
…t Robustness

This commit implements several corrections and missing mechanics:

1.  **Special Conditions Implemented/Fixed**:
    *   Poisoned: Now correctly applies 10 damage during Pokemon Check-Up (`Pokemon.controlePokemon`).
    *   Asleep:
        *   Wake-up coin flip added to `Pokemon.controlePokemon`.
        *   Asleep Pokemon are now prevented from attacking (`Joueur.getAttaquesPossibles`) or retreating (`Pokemon.peutRetraite`).
    *   Paralyzed:
        *   Paralyzed Pokemon are now prevented from attacking or retreating (via shared logic with Asleep).
        *   Paralysis is now correctly removed at the end of the affected Pokemon's owner's turn (`Pokemon.onFinTour`).
    *   Confused:
        *   Pre-attack coin flip logic added to `Joueur.attaquer`. If tails, Pokemon damages itself (30 damage) and attack fails. If heads, attack proceeds.

2.  **Deck Shuffling After Search/Return Effects**:
    *   Nidoqueen's Talent: Deck is now shuffled after a Pokemon is added to hand (`TalentNidoqueen.carteChoisie`).
    *   Pokemon Communication: Deck is now shuffled after a Pokemon is taken from the deck, or if you decline to take one after the initial search (`SuiteChoixCommunicationPokemon.carteChoisie` and `passer`).
    *   Recyclage d'Energie (Shuffle to Deck option): Deck is now shuffled after selected energies are returned to it (`OptionMelangeRecyclageDEnergie.carteChoisie`).

3.  **Improved Robustness of Card Effects**:
    *   Dracolosse "Impact du Dragon" attack: The `ImpactDuDragon` state now correctly handles cases where Dracolosse has fewer than 3 energies to discard. It will discard available energies up to 3. If no energies can be/need to be discarded, the attack sequence now correctly proceeds by calling `finAttaque()` instead of soft-locking.

These changes address several critical gameplay issues and bring the game mechanics closer to standard TCG rules and expected behavior.