### PR TITLE
Gameplay Corrections Part 2: Effect Robustness & Talent Refactor

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/pokemon/Lanturn.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/cartes/pokemon/Lanturn.java
@@ -6,9 +6,14 @@ import java.util.stream.Collectors;
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.Joueur;
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.Pokemon;
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.Type;
+import fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.Carte; // Ensure this is imported
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.etatsJoueur.attaque.FrapEclair;
+import fr.umontpellier.iut.ptcgJavaFX.mecanique.etatsJoueur.talent.EtatChoixUtiliserEnergyGrounding;
 
 public class Lanturn extends CartePokemonEvolution {
+
+    private boolean talentEnergyGroundingUtiliseCeTour = false;
+
     public Lanturn() {
         super(
                 "Lanturn",
@@ -24,40 +29,78 @@ public class Lanturn extends CartePokemonEvolution {
         ajouterAttaque(new Attaque("Frap'Éclair", this, Type.ELECTRIQUE, 2, Type.INCOLORE, 1) {
             @Override
             public void attaquer(Joueur joueur) {
-                joueur.setPeutDefausserEnergie(true);
                 joueur.setEtatCourant(new FrapEclair(joueur));
-                joueur.setPeutDefausserEnergie(true);
             }
         });
     }
 
+    // Removed old onPokemonKO method
+
     @Override
-    public void onPokemonKO(Pokemon koPokemon, Joueur ownerOfLanturn) {
-        // Condition: Was KO by opponent's attack? Approximation: is it opponent's turn?
-        // This is a simplification. A more robust solution needs better game state info.
-        boolean koByOpponentAttack = (ownerOfLanturn.getJeu().getJoueurActif() == ownerOfLanturn.getAdversaire());
-        if (!koByOpponentAttack) {
+    public boolean peutUtiliserTalent() {
+        // Simplified check for UI hint. Full check is in utiliserTalent.
+        return !talentEnergyGroundingUtiliseCeTour;
+    }
+
+    @Override
+    public void utiliserTalent(Joueur joueur) {
+        if (talentEnergyGroundingUtiliseCeTour) {
+            if (joueur.getJeu() != null) {
+                joueur.getJeu().instructionProperty().setValue("Energy Grounding a déjà été utilisé ce tour par ce Lanturn.");
+            }
             return;
         }
 
-        // TODO: Add "once per turn" check for this specific Lanturn/power if needed.
-        // if (ownerOfLanturn.aDejaUtiliseTalentCeTour("EnergyGrounding_" + this.getId())) return;
-
-        Pokemon thisLanturnInPlay = ownerOfLanturn.getPokemon(this);
-        if (thisLanturnInPlay == null || thisLanturnInPlay.estKO()) {
+        Pokemon koPokemonAllie = joueur.getPokemonAllieKOAuTourPrecedent();
+        if (koPokemonAllie == null) {
+            if (joueur.getJeu() != null) {
+                joueur.getJeu().instructionProperty().setValue("Aucun Pokémon allié n'a été KO par une attaque au tour précédent.");
+            }
             return;
         }
 
-        List<fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.Carte> basicEnergiesOnKOPokemon = koPokemon.getCartes().stream()
-            .filter(fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.Carte::isBasicEnergy) // Relies on isBasicEnergy() method in Carte.java
-            .collect(java.util.stream.Collectors.toList());
+        // Check if KO happened on opponent's last turn.
+        // joueur.getTourPokemonAllieKO() is the turn number the KO occurred.
+        // joueur.getJeu().getCompteurTour() is the current turn number.
+        // Talent is used on player's current turn. So current turn must be KO_turn + 1.
+        if (joueur.getJeu() == null || joueur.getJeu().getCompteurTour() != joueur.getTourPokemonAllieKO() + 1) {
+            if (joueur.getJeu() != null) {
+                joueur.getJeu().instructionProperty().setValue("Energy Grounding ne peut être utilisé que le tour suivant le KO.");
+            }
+            return;
+        }
+
+        List<Carte> basicEnergiesOnKOPokemon = koPokemonAllie.getCartes().stream()
+            .filter(Carte::isBasicEnergy) // Relies on Carte.isBasicEnergy()
+            .collect(Collectors.toList());
 
         if (basicEnergiesOnKOPokemon.isEmpty()) {
+            if (joueur.getJeu() != null && koPokemonAllie.getCartePokemon() != null) {
+                joueur.getJeu().instructionProperty().setValue(koPokemonAllie.getCartePokemon().getNom() + " (KO) n'avait pas d'énergie de base attachée.");
+            } else if (joueur.getJeu() != null) {
+                 joueur.getJeu().instructionProperty().setValue("Le Pokémon KO n'avait pas d'énergie de base attachée.");
+            }
             return;
         }
 
-        ownerOfLanturn.setEtatCourant(
-            new fr.umontpellier.iut.ptcgJavaFX.mecanique.etatsJoueur.talent.EtatChoixUtiliserEnergyGrounding(ownerOfLanturn, koPokemon, thisLanturnInPlay, basicEnergiesOnKOPokemon)
+        Pokemon thisLanturnInPlay = joueur.getPokemon(this); // 'this' refers to this CartePokemon instance
+        if (thisLanturnInPlay == null || thisLanturnInPlay.estKO()) {
+             if (joueur.getJeu() != null) {
+                joueur.getJeu().instructionProperty().setValue("Lanturn doit être en jeu et non KO pour utiliser son talent.");
+            }
+            return;
+        }
+
+        // All conditions met, proceed with talent
+        this.talentEnergyGroundingUtiliseCeTour = true;
+        joueur.setEtatCourant(
+            new EtatChoixUtiliserEnergyGrounding(joueur, koPokemonAllie, thisLanturnInPlay, basicEnergiesOnKOPokemon)
         );
+    }
+
+    @Override
+    public void onFinTour(Joueur joueur) {
+        super.onFinTour(joueur); // Handles peutEvoluer = true; and other base class onFinTour logic
+        this.talentEnergyGroundingUtiliseCeTour = false;
     }
 }


### PR DESCRIPTION
This commit implements further corrections and improvements:

1.  **Improved Robustness of Card Effects**:
    *   Dracolosse "Impact du Dragon" attack: The `ImpactDuDragon` state now correctly handles cases where Dracolosse has fewer than 3 energies to discard. It will discard available energies up to 3. If no energies can be/need to be discarded, the attack sequence now correctly proceeds by calling `finAttaque()` instead of soft-locking. (Continuation of work from previous commit's Step 3).

2.  **Addressed Talent/Ability Trigger and Frequency**:
    *   Lanturn "Energy Grounding" Ability:
        *   Refactored from an `onPokemonKO` trigger to a proper activatable talent.
        *   Added fields (`pokemonAllieKOAuTourPrecedent`, `tourPokemonAllieKO`) and a setter method (`setPokemonAllieKOParAttaqueAdversaire`) to `Joueur.java` to track when one of its Pokémon is KO'd by an opponent's attack.
        *   Modified `Joueur.defausserPokemonsKO()` to call `setPokemonAllieKOParAttaqueAdversaire` for the player whose Pokémon is KO'd by an opponent's attack.
        *   Modified `Joueur.onDebutTour()` to invalidate the `pokemonAllieKOAuTourPrecedent` if it wasn't from the immediately preceding turn.
        *   In `Lanturn.java`:
            *   Removed the old `onPokemonKO` method.
            *   Added `talentEnergyGroundingUtiliseCeTour` flag, reset in `onFinTour`.
            *   `peutUtiliserTalent()` (no-args) provides a basic check on this flag.
            *   `utiliserTalent(Joueur joueur)` now contains the full logic:
                *   Checks the `talentEnergyGroundingUtiliseCeTour` flag.
                *   Checks `joueur.getPokemonAllieKOAuTourPrecedent()` and the turn timing.
                *   Checks for basic energies on the KO'd Pokémon.
                *   Checks if this Lanturn is in play and not KO.
                *   If all conditions pass, sets the turn flag and transitions to `EtatChoixUtiliserEnergyGrounding`.
                *   Sets appropriate UI instructions if conditions are not met.

These changes enhance the correctness of specific card effects and ability activations according to standard TCG rules.