### PR TITLE
Gameplay Corrections and Refinements - Full Set

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/Jeu.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/Jeu.java
@@ -357,4 +357,23 @@ public class Jeu implements IJeu {
     public void talentAEteRefuse() {
         getJoueurActif().getEtatCourant().talentAEteRefuse();
     }
+
+    public void logRevealCard(Joueur revealingPlayer, Carte revealedCard, String contextMessage) {
+        if (revealingPlayer == null || revealedCard == null) {
+            System.err.println("LOG_REVEAL_ERROR: Player or Card was null.");
+            return;
+        }
+        String cardName = revealedCard.getNom() != null ? revealedCard.getNom() : "Unknown Card";
+        String cardId = revealedCard.getId() != null ? revealedCard.getId() : "N/A";
+
+        String logMessage = String.format("LOG_REVEAL: %s revealed %s (ID: %s). Context: %s",
+                                            revealingPlayer.getNom(),
+                                            cardName,
+                                            cardId,
+                                            contextMessage);
+        System.out.println(logMessage);
+
+        // Optional: update instruction property. This might be immediately overwritten by subsequent state changes.
+        // instructionProperty().setValue(revealingPlayer.getNom() + " a révélé " + cardName + ".");
+    }
 }

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/talent/TalentNidoqueen.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/talent/TalentNidoqueen.java
@@ -22,8 +22,12 @@ public class TalentNidoqueen extends EtatJoueur {
                         .map(Carte::getId)
                         .toList();
         if (!choixPossibles.isEmpty() && choixPossibles.contains(numCarte)) {
+            Carte carteRevelee = Carte.get(numCarte); // Get the card object before moving
             joueur.deplacerCarteComplementaire(numCarte, new PiocheVersMain());
-            joueur.melangerPioche(); // Added this line
+            if (carteRevelee != null && joueur.getJeu() != null) { // Add null checks for safety
+                joueur.getJeu().logRevealCard(joueur, carteRevelee, "Searched from deck with Nidoqueen's Talent");
+            }
+            joueur.melangerPioche();
             joueur.viderListChoixComplementaires();
             joueur.setEtatCourant(new TourNormal(joueur));
         }

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/tournormal/carteenjeu/EnJeuCommunicationPokemon.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/tournormal/carteenjeu/EnJeuCommunicationPokemon.java
@@ -20,6 +20,11 @@ public class EnJeuCommunicationPokemon extends CarteEnJeu {
                 .map(Carte::getId)
                 .toList();
         if (!choixPossibles.isEmpty() && choixPossibles.contains(numCarte)) {
+            Carte carteARevelerEtRetourner = Carte.get(numCarte); // Get the card object
+            if (carteARevelerEtRetourner != null && joueur.getJeu() != null) { // Add null checks
+                joueur.getJeu().logRevealCard(joueur, carteARevelerEtRetourner, "Returned to deck with Pokémon Communication");
+            }
+
             List<Carte> pokemonsDeLaPioche = joueur.getCartesPioche().stream()
                     .filter(c -> c.getTypePokemon() != null)
                     .toList();

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/tournormal/carteenjeu/EnJeuRecyclageDEnergie.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/tournormal/carteenjeu/EnJeuRecyclageDEnergie.java
@@ -17,7 +17,7 @@ public class EnJeuRecyclageDEnergie extends CarteEnJeu {
         if (joueur.getChoixComplementaires().isEmpty()) { // dans le cas où on rechoisit l'option
             joueur.setPeutAjouter(false);
             List<Carte> cartesEnergieDeDefausse = joueur.getCartesDefausse().stream()
-                    .filter(c -> c.getTypeEnergie() != null)
+                    .filter(Carte::isBasicEnergy) // Changed this line
                     .toList();
             if (!cartesEnergieDeDefausse.isEmpty()) {
                 joueur.setListChoixComplementaires(cartesEnergieDeDefausse);
@@ -33,7 +33,7 @@ public class EnJeuRecyclageDEnergie extends CarteEnJeu {
         if (joueur.getChoixComplementaires().isEmpty()) { // dans le cas où on rechoisit l'option
             joueur.setPeutMelanger(false);
             List<Carte> cartesEnergieDeDefausse = joueur.getCartesDefausse().stream()
-                    .filter(c -> c.getTypeEnergie() != null)
+                    .filter(Carte::isBasicEnergy) // Changed this line
                     .toList();
             if (!cartesEnergieDeDefausse.isEmpty()) {
                 joueur.setListChoixComplementaires(cartesEnergieDeDefausse);

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/tournormal/carteenjeu/SuiteChoixCommunicationPokemon.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/mecanique/etatsJoueur/tournormal/carteenjeu/SuiteChoixCommunicationPokemon.java
@@ -17,15 +17,14 @@ public class SuiteChoixCommunicationPokemon extends CarteEnJeu {
     public void carteChoisie(String numCarte) {
         List<String> choixPossibles = joueur.getChoixComplementaires().stream().map(Carte::getId).toList();
         if (!choixPossibles.isEmpty() && choixPossibles.contains(numCarte)) {
+            Carte carteReveleeDuDeck = Carte.get(numCarte); // Get the card object
             joueur.deplacerCarteComplementaire(numCarte, new PiocheVersMain());
-            // It's important to clear choixComplementaires *before* shuffling if it contained references to pioche.
-            // However, deplacerCarteComplementaire already removes the card from choixComplementaires.
-            // If viderListChoixComplementaires() is meant to clear the list that was populated from the deck,
-            // it should be called before shuffling.
-            // For safety, let's assume viderListChoixComplementaires clears the temporary list of choices.
-            joueur.viderListChoixComplementaires(); // Clear the list of choices from deck
-            joueur.melangerPioche(); // Added this line
-            onFinAction(); // Proceeds to TourNormal
+            if (carteReveleeDuDeck != null && joueur.getJeu() != null) { // Add null checks
+                joueur.getJeu().logRevealCard(joueur, carteReveleeDuDeck, "Searched from deck with Pokémon Communication");
+            }
+            joueur.viderListChoixComplementaires();
+            joueur.melangerPioche();
+            onFinAction();
         }
     }
 


### PR DESCRIPTION
This commit implements a comprehensive set of corrections and missing mechanics I identified during code review:

1.  **Special Conditions Implemented/Fixed**:
    *   Poisoned: Applies 10 damage during Pokemon Check-Up (`Pokemon.controlePokemon`).
    *   Asleep: Wake-up coin flip added (`Pokemon.controlePokemon`); action prevention for attack/retreat added (`Joueur.getAttaquesPossibles`, `Pokemon.peutRetraite`).
    *   Paralyzed: Action prevention for attack/retreat added; removal at end of owner's next turn implemented (`Pokemon.onFinTour`).
    *   Confused: Pre-attack coin flip logic (self-damage and attack failure on tails) added to `Joueur.attaquer`.

2.  **Deck Shuffling After Search/Return Effects**:
    *   Nidoqueen's Talent: Deck now shuffles after a card is taken (`TalentNidoqueen.carteChoisie`).
    *   Pokemon Communication: Deck now shuffles after card is taken from deck or if you pass (`SuiteChoixCommunicationPokemon.carteChoisie`, `passer`).
    *   Recyclage d'Energie (Shuffle mode): Deck now shuffles after energies are returned (`OptionMelangeRecyclageDEnergie.carteChoisie`).

3.  **Improved Robustness of Card Effects**:
    *   Dracolosse "Impact du Dragon": `ImpactDuDragon` state now correctly handles cases with insufficient energy to discard (discards available up to 3, proceeds instead of soft-locking).

4.  **Addressed Talent/Ability Trigger and Frequency**:
    *   Lanturn "Energy Grounding":
        *   Refactored from `onPokemonKO` to an activatable talent in `Lanturn.java`.
        *   `Joueur.java` now tracks `pokemonAllieKOAuTourPrecedent` and `tourPokemonAllieKO`, set during KO processing if KO by opponent's attack. This info is cleared appropriately in `Joueur.onDebutTour`.
        *   Lanturn's `utiliserTalent` now correctly checks timing, once-per-turn status, and energy presence on the KO'd Pokemon before activating.

5.  **Implemented Card Revealing (Conceptual Logging)**:
    *   Added `Jeu.logRevealCard()` method for logging card reveals.
    *   Calls to `logRevealCard` implemented in Nidoqueen's talent and Pokémon Communication at appropriate points to signify when cards should be revealed to your opponent.

6.  **Refined Basic vs. Any Energy Targeting**:
    *   Recyclage d'Energie: Now correctly filters for and interacts with *basic* Energy cards from the discard pile, aligning with standard TCG card text (`EnJeuRecyclageDEnergie.java` modified to use `Carte::isBasicEnergy`).

These changes significantly improve the game's adherence to standard Pokémon TCG rules, enhance the robustness of card effects, and complete several previously missing mechanics.