### PR TITLE
Hotfix: Align Java controller classes with FXML root element changes

### DIFF
--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueAdversaire.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueAdversaire.java
@@ -24,12 +24,13 @@ import javafx.event.ActionEvent; // Added import
 import javafx.scene.layout.HBox;
 // import javafx.scene.layout.Region; // For placeholders or card backs - ImageView will be used
 import javafx.scene.layout.VBox;
+import javafx.scene.layout.BorderPane; // Added for BorderPane
 
 import java.io.IOException;
 import java.util.List; // For energieProperty value type
 import java.util.Map; // For iterating energy map
 
-public class VueAdversaire extends VBox {
+public class VueAdversaire extends BorderPane { // Changed from VBox to BorderPane
     private static final int MAX_BENCH_SLOTS = 5; // Matching VueJoueurActif
 
     // Constants for image sizes

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueDuJeu.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueDuJeu.java
@@ -7,11 +7,12 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 // import javafx.scene.control.Button; // No longer used
 import javafx.scene.control.Label;
-import javafx.scene.layout.VBox;
+import javafx.scene.layout.BorderPane; // Changed from VBox to BorderPane
+import javafx.scene.layout.VBox; // Keep for other VBox uses or if needed by FXML elements
 
 import java.io.IOException;
 
-public class VueDuJeu extends VBox {
+public class VueDuJeu extends BorderPane { // Changed from VBox to BorderPane
 
     private IJeu jeu; // Keep this to pass to VueJoueurActif
     @FXML

--- a/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
+++ b/src/main/java/fr/umontpellier/iut/ptcgJavaFX/vues/VueJoueurActif.java
@@ -24,6 +24,7 @@ import javafx.scene.image.ImageView; // Added for image display
 import javafx.scene.layout.FlowPane; // Added for attaquesPane
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.scene.layout.BorderPane; // Added for BorderPane
 import javafx.scene.Node; // Added for mettreAJourStyleSelectionPokemon
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.Carte; // Added for mettreAJourStyleSelectionPokemon
 import fr.umontpellier.iut.ptcgJavaFX.mecanique.cartes.pokemon.Attaque; // Added for attaques
@@ -36,7 +37,7 @@ import java.util.HashMap; // Added for new Maps
 import java.util.List; // Added for type in MapChangeListener
 import java.util.Map; // Added for new Maps
 
-public class VueJoueurActif extends VBox {
+public class VueJoueurActif extends BorderPane { // Changed from VBox to BorderPane
 
     private static final int MAX_BENCH_SLOTS = 5; // Added constant
 


### PR DESCRIPTION
I corrected the inheritance of Java controller classes to match their corresponding FXML root elements:
- VueDuJeu.java now extends BorderPane (was VBox).
- VueJoueurActif.java now extends BorderPane (was VBox).
- VueAdversaire.java now extends BorderPane (was VBox).

This fixes the javafx.fxml.LoadException: "Root is not an instance of javafx.scene.layout.BorderPane" that occurred after the FXML files were refactored to use BorderPane as their root for layout improvements. This commit should allow the application to start correctly with the new FXML structures.